### PR TITLE
Failing release (v0.5.0)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           type=semver,pattern={{version}}
           type=ref,event=branch
           type=sha,format=short
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build Docker image
       uses: docker/build-push-action@v5

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,3 +22,21 @@ jobs:
 
     - name: Run tests
       run: go test -v ./...
+
+    - name: Extract metadata for Docker
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/${{ github.repository_owner }}/ws2wh
+        tags: |
+          type=semver,pattern={{version}}
+          type=ref,event=branch
+          type=sha,format=short
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v5
+      with:
+        context: .
+        push: false
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.24.4 AS builder
+FROM golang:1.24.5 AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
fix:

- go version update 
- extended build job with docker image build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Go base image to version 1.24.5 for Docker builds.
  * Enhanced the build workflow to generate Docker image metadata and build images with semantic tags after tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->